### PR TITLE
Bam. .select() is all we have to call on the card title to trigger a save

### DIFF
--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -181,8 +181,6 @@ var Scrummo = {
 				updatedTitle = titleTextPoints.concat(titleText);
 			}
 
-			console.log ( "updatedTitle == " + updatedTitle );
-
 			_this.saveNewTitle(updatedTitle);
 			_this.saveNewComment(commentPoints);
 		});
@@ -306,16 +304,8 @@ var Scrummo = {
 		Updates the title of the card, and re-saves it to the Trello's DB.
 	**/
 	saveNewTitle: function(value) {
-	  	$("h2.card-detail-title-assist.js-title-helper").trigger("click");
-	  	//$("textarea.mod-card-back-title.js-card-detail-title-input").val(value);
-	  	//$("input.js-save-edit").trigger("click"); //Save
 
-		var $titleInput = $('.js-card-detail-title-input');
-		$titleInput
-		.trigger('click')
-		.val(value)
-		.trigger('focusout');
-
+		$('.js-card-detail-title-input').val(value).select();
 	},
 
 	/*
@@ -339,6 +329,7 @@ var Scrummo = {
 		var _this = this; //context
 
 		$(this.cardDetail).each(function() {
+			
 			var myText = $(this).find(_this.listTitle).text();
 			var points = 0; //Defaults to ZERO
 


### PR DESCRIPTION
That took ages. I finally searched the Trello js for "is-editing" and saw what events it was firing at the same time the class was being added to the textarea. Once it worked I eliminated events one by one until only "select" was left and it still worked. So, I think this is a fix.